### PR TITLE
Add initial test suite scaffold, using karma + jasmine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ attendease.undoCheckin('event')
 attendease.undoCheckin('instance', instanceId)
 ```
 
-### Building
+### Building and testing
 
 Make sure you install any development dependencies.
 
@@ -110,7 +110,7 @@ Make sure you install any development dependencies.
 npm install
 ```
 
-Build the library into dist (using webpack).
+Build the library into `./dist`.
 
 ```
 npm run build
@@ -120,4 +120,10 @@ Or to have webpack watch files for changes and do builds automatically.
 
 ```
 npm run watch
+```
+
+And to run the test suite.
+
+```
+npm test
 ```

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,26 @@
+module.exports = function(config) {
+  config.set({
+    browsers: ['PhantomJS'],
+    files: [
+      'https://code.jquery.com/jquery-2.1.4.min.js',
+      { pattern: 'tests.webpack.js', watched: false },
+    ],
+    frameworks: ['jasmine-ajax', 'jasmine'],
+    preprocessors: {
+      'tests.webpack.js': ['webpack'],
+    },
+    reporters: ['dots'],
+    singleRun: true,
+    webpack: {
+      module: {
+        loaders: [
+          { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' },
+        ],
+      },
+      watch: true,
+    },
+    webpackServer: {
+      noInfo: true,
+    },
+  })
+}

--- a/package.json
+++ b/package.json
@@ -12,9 +12,20 @@
     "jquery": "~2.1.0"
   },
   "devDependencies": {
+    "babel-core": "^5.5.6",
+    "babel-loader": "^5.1.4",
+    "jasmine": "^2.3.1",
+    "jasmine-core": "^2.3.4",
+    "karma": "^0.12.36",
+    "karma-jasmine": "^0.3.5",
+    "karma-jasmine-ajax": "^0.1.12",
+    "karma-phantomjs-launcher": "^0.2.0",
+    "karma-webpack": "^1.5.1",
+    "phantomjs": "^1.9.17",
     "webpack": "*"
   },
   "scripts": {
+    "test": "karma start",
     "build": "webpack src/attendease.js dist/attendease.js",
     "watch": "webpack src/attendease.js dist/attendease.js --watch"
   }

--- a/src/__tests__/client-test.js
+++ b/src/__tests__/client-test.js
@@ -1,0 +1,68 @@
+import Client from '../client'
+
+jasmine.Ajax.install()
+
+describe('Client', () => {
+  const client = new Client('hello')
+
+  describe('#apiRoot()', () => {
+    it('returns the API root using the event subdomain', () => {
+      expect(client.apiRoot()).toBe('https://hello.attendease.com/')
+    })
+  })
+
+  describe('#login()', () => {
+    let request
+
+    beforeEach(() => {
+      client.login({
+        email: 'hello@attendease.com',
+        password: 'YbAd8TzopfRg'
+      })
+
+      request = jasmine.Ajax.requests.mostRecent()
+
+      request.respondWith({
+        status: '200',
+        responseText: '{"email":"hello@attendease.com","access_token":"a"}'
+      })
+    })
+
+    it('POSTs to api/authenticate with credentials', () => {
+      expect(request.url).toBe('https://hello.attendease.com/api/authenticate.json')
+      expect(request.method).toBe('POST')
+      expect(request.data()).toEqual({
+        email: ['hello@attendease.com'],
+        password: ['YbAd8TzopfRg']
+      })
+    })
+
+    it('Stores the user and credentials in localStorage', () => {
+      expect(localStorage.user_details).toBe('{"email":"hello@attendease.com","access_token":"a"}')
+      expect(localStorage.credentials).toBe('{"attendee_token":"a"}')
+    })
+  })
+
+  describe('#logout()', () => {
+    beforeEach(() => {
+      client.login({
+        email: 'hello@attendease.com',
+        password: 'YbAd8TzopfRg'
+      })
+
+      const request = jasmine.Ajax.requests.mostRecent()
+
+      request.respondWith({
+        status: '200',
+        responseText: '{"email":"hello@attendease.com","access_token":"a"}'
+      })
+
+      client.logout()
+    })
+
+    it('Clears localstorage so user / credentials are no longer stored', () => {
+      expect(localStorage.user_details).toBe(undefined)
+      expect(localStorage.credentials).toBe(undefined)
+    })
+  })
+})

--- a/tests.webpack.js
+++ b/tests.webpack.js
@@ -1,0 +1,2 @@
+var context = require.context('./src', true, /-test\.js$/)
+context.keys().forEach(context)


### PR DESCRIPTION
## Changes

- Added karma + jasmine testing setup.

- Added initial tests for `Client#apiRoot`, `Client#login`, `Client#logout`.

## Running

To run the test suite, first `npm install` if you haven't and then run:

```
npm test
```

Connected to #5